### PR TITLE
Add set_limit and helpers for enabling and disabling

### DIFF
--- a/pyjuicenet/__init__.py
+++ b/pyjuicenet/__init__.py
@@ -95,13 +95,19 @@ class Charger:
 
     @property
     def max_charging_amperage(self) -> int:
-        """Get the maximum charging limit time from the smaller of the wire rating and unit rating."""
+        """Get the maximum charging limit time from the smaller of the wire rating and unit rating.
+        This can be used along with set limit to enable the charger at full capacity"""
         return min(self.json_info.get("amps_wire_rating"), self.json_info.get("amps_unit_rating"))
 
     @property
     def current_charging_amperage_limit(self) -> int:
         """Get the current amperage charging limit for the charger."""
         return self.json_state.get("charging", {}).get("amps_limit")
+
+    @property
+    def charger_enabled(self) -> bool:
+        """Is the charger allowing amps to flow."""
+        return self.current_charging_amperage_limit > 0
 
     async def set_charging_amperage_limit(self, amperage: int) -> bool:
         """Set the amperage limit of the charger. 0 will disable the charger."""
@@ -112,6 +118,14 @@ class Charger:
             await self.update_state(True)
 
         return response['success']
+
+    async def enable_charger(self):
+        """Enable charger for max support amperage"""
+        return await self.set_charging_amperage_limit(self.max_charging_amperage)
+
+    async def disable_charger(self):
+        """Disable all charging activity"""
+        return await self.set_charging_amperage_limit(0)
 
     async def set_override(self, charge_now) -> bool:
         """Set to override schedule or not."""

--- a/pyjuicenet/__init__.py
+++ b/pyjuicenet/__init__.py
@@ -239,20 +239,6 @@ class Api:
         )
         return await response.json()
 
-    async def get_commands(self, charger: Charger):
-        """Fetch more info about the charger."""
-        data = {
-            "cmd": "list_commands",
-            "device_id": self.uuid,
-            "token": charger.token,
-            "account_token": self.api_token
-        }
-
-        response = await self.session.post(
-            f"{BASE_URL}/box_api_secure", json=data,
-        )
-        return await response.json()
-
     async def set_limit(self, charger: Charger, amperage_limit: int):
         """Set the amperage limit of the charger. 0 will disable the charger."""
         data = {


### PR DESCRIPTION
I saw the other pull request regarding the limits, however, I did not have the same results that were mentioned in the other pull request.

For me if I set the charger to 0 AMPS it stays at 0 AMPS. I think perhaps there are some nuances to set limit for cases between 0 and the max limit that I haven't fully explored. However, for the case I am most interested (Home Assistant) it looks like we can safely enable/disable at the charger using 0 and the Max charging rate.